### PR TITLE
Removed panel border and reduced opacity

### DIFF
--- a/EzPoison.lua
+++ b/EzPoison.lua
@@ -125,7 +125,6 @@ function EZP.ConfigFrame:ConfigureUI()
 	end
 	
 	self:SetScale(EZPcfg.Scale)
-	-- local backdrop = {bgFile = "Interface\\TutorialFrame\\TutorialFrameBackground",  edgeFile="Interface\\Tooltips\\UI-Tooltip-Border", tile=true,tileSize = 16, edgeSize = 16, insets = { left = 3, right = 5, top = 3, bottom = 5 }}  -- path to the background texture
 	local backdrop = {bgFile = "Interface\\TutorialFrame\\TutorialFrameBackground", tile=true,tileSize = 16, edgeSize = 16, insets = { left = 3, right = 5, top = 3, bottom = 5 }}  -- path to the background texture
 	self:SetBackdrop(backdrop)
 	self:SetBackdropColor(0,0,0,0.25)

--- a/EzPoison.lua
+++ b/EzPoison.lua
@@ -125,9 +125,10 @@ function EZP.ConfigFrame:ConfigureUI()
 	end
 	
 	self:SetScale(EZPcfg.Scale)
-	local backdrop = {bgFile = "Interface\\TutorialFrame\\TutorialFrameBackground", edgeFile="Interface\\Tooltips\\UI-Tooltip-Border", tile=true,tileSize = 16, edgeSize = 16, insets = { left = 3, right = 5, top = 3, bottom = 5 }}  -- path to the background texture
+	-- local backdrop = {bgFile = "Interface\\TutorialFrame\\TutorialFrameBackground",  edgeFile="Interface\\Tooltips\\UI-Tooltip-Border", tile=true,tileSize = 16, edgeSize = 16, insets = { left = 3, right = 5, top = 3, bottom = 5 }}  -- path to the background texture
+	local backdrop = {bgFile = "Interface\\TutorialFrame\\TutorialFrameBackground", tile=true,tileSize = 16, edgeSize = 16, insets = { left = 3, right = 5, top = 3, bottom = 5 }}  -- path to the background texture
 	self:SetBackdrop(backdrop)
-	self:SetBackdropColor(0,0,0,0.8)
+	self:SetBackdropColor(0,0,0,0.25)
 	self:SetWidth(82)
 	self:SetHeight(48)
 	self:SetPoint("TOPLEFT",EZPcfg.PosX,EZPcfg.PosY)


### PR DESCRIPTION
In my opinion the backdrop of the panel is way too eye catching. I've removed the border and reduced the opacity of the panel.

Example of the updated GUI,
![image](https://github.com/user-attachments/assets/3a0d8f79-684e-4c47-a5dd-51fd488ffede)
